### PR TITLE
Add scrubber POC

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,5 +14,7 @@ module.exports = {
   ],
   rules: {
     "no-console": "off",
+    "no-plusplus": "off",
+    "no-continue": "off",
   },
 };

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,16 @@
 import cli from "./cli";
 
+import Scrubber from "./scrubber/scrubber";
+
+async function scrub() {
+  try {
+    const scrubber = new Scrubber();
+    await scrubber.parseConfig("scrubber/scrubberConfig.json");
+    await scrubber.start();
+  } catch (err) {
+    console.log(err);
+  }
+}
+
 cli(process.argv);
+scrub();

--- a/index.ts
+++ b/index.ts
@@ -1,12 +1,15 @@
 import cli from "./cli";
 
 import Scrubber from "./scrubber/scrubber";
+import { ScrubberAction } from "./scrubber/scrubberTypes";
 
 async function scrub() {
   try {
+    const actions: ScrubberAction[] = [{ type: "remove", tags: ["@remove"] }];
     const scrubber = new Scrubber();
+
     await scrubber.parseConfig("scrubber/scrubberConfig.json");
-    await scrubber.start();
+    await scrubber.start(actions);
   } catch (err) {
     console.log(err);
   }

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   "scripts": {
     "dev": "ts-node index.ts",
     "lint": "eslint . --ext .ts,.js",
-    "lint-fix": "eslint . --ext .ts,.js --fix && prettier --write **/*.ts **/*.js",
-    "prod": "tsc -p . && node bin/index.js"
+    "lint-fix": "eslint . --ext .ts,.js --fix"
   },
   "devDependencies": {
     "@types/figlet": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "dev": "ts-node index.ts",
     "lint": "eslint . --ext .ts,.js",
-    "lint-fix": "eslint . --ext .ts,.js --fix"
+    "lint-fix": "eslint . --ext .ts,.js --fix",
+    "prod": "tsc -p . && node bin/index.js"
   },
   "devDependencies": {
     "@types/figlet": "^1.2.1",

--- a/scrubber/scrubber.ts
+++ b/scrubber/scrubber.ts
@@ -1,0 +1,59 @@
+import fs from "fs";
+import { ScrubberActionType, ScrubberConfig } from "./scrubberTypes";
+
+async function getConfigFile(filename: string): Promise<ScrubberConfig> {
+  try {
+    const configString = await fs.readFileSync(filename, "utf8");
+    return JSON.parse(configString);
+  } catch (err) {
+    console.log("Failed to read file ", filename);
+    throw err;
+  }
+}
+
+class Scrubber {
+  tags: { [key: string]: ScrubberActionType } = {};
+
+  async parseConfig(filename: string): Promise<void> {
+    const config = await getConfigFile(filename);
+    config.actions.forEach((action) => {
+      action.tags.forEach((tag: string) => {
+        this.tags[tag] = action.type;
+      });
+    });
+  }
+
+  async start(): Promise<void> {
+    const text: string = await fs.readFileSync("test", "utf8");
+    const lines: string[] = text.split("\n");
+    const scrubbedLines: string[] = [];
+
+    // TODO Handle nested tags
+
+    const tagsSeen: string[] = [];
+    let skip = false;
+
+    for (let i = 0; i < lines.length; ++i) {
+      const line = lines[i];
+
+      if (line in this.tags) {
+        if (tagsSeen.length && tagsSeen[tagsSeen.length - 1] === line) {
+          tagsSeen.pop();
+        } else {
+          tagsSeen.push(line);
+        }
+        if (this.tags[line] === "remove" && tagsSeen.length < 2) {
+          skip = tagsSeen.length > 0;
+        }
+        continue;
+      }
+
+      if (skip) continue;
+
+      scrubbedLines.push(line);
+    }
+    await fs.writeFileSync("test", scrubbedLines.join("\n"));
+  }
+}
+
+export default Scrubber;

--- a/scrubber/scrubberConfig.json
+++ b/scrubber/scrubberConfig.json
@@ -1,13 +1,9 @@
 {
   "actions": [
     {
-      "type": "remove",
-      "tags": ["@remove"]
-    },
-    {
-      "type": "remove",
-      "tags": ["@remove2"]
+      "type": "keep",
+      "tags": ["@remove", "@remove2"]
     }
   ],
-  "files": ["*.js"]
+  "dirs": ["test_dir"]
 }

--- a/scrubber/scrubberConfig.json
+++ b/scrubber/scrubberConfig.json
@@ -1,0 +1,13 @@
+{
+  "actions": [
+    {
+      "type": "remove",
+      "tags": ["@remove"]
+    },
+    {
+      "type": "remove",
+      "tags": ["@remove2"]
+    }
+  ],
+  "files": ["*.js"]
+}

--- a/scrubber/scrubberTypes.ts
+++ b/scrubber/scrubberTypes.ts
@@ -1,0 +1,15 @@
+/*
+Types required by the scrubber tool.
+*/
+
+export type ScrubberActionType = "remove" | "keep";
+
+export type ScrubberAction = {
+  type: ScrubberActionType;
+  tags: string[];
+};
+
+export type ScrubberConfig = {
+  actions: ScrubberAction[];
+  files: string[];
+};

--- a/scrubber/scrubberTypes.ts
+++ b/scrubber/scrubberTypes.ts
@@ -11,5 +11,7 @@ export type ScrubberAction = {
 
 export type ScrubberConfig = {
   actions: ScrubberAction[];
-  files: string[];
+  dirs: string[];
 };
+
+export type TagNameToAction = { [key: string]: ScrubberActionType };

--- a/test_dir/test
+++ b/test_dir/test
@@ -1,0 +1,5 @@
+@remove {
+    this should be gone
+} @remove
+
+hello world

--- a/test_dir/test.js
+++ b/test_dir/test.js
@@ -1,0 +1,5 @@
+// @remove {
+console.log("this should be gone");
+// } @remove
+
+console.log("hello world");

--- a/test_dir/test.py
+++ b/test_dir/test.py
@@ -1,0 +1,5 @@
+# @remove {
+    print('this should be gone')
+# } @remove
+
+print('hello world')

--- a/test_dir/test1
+++ b/test_dir/test1
@@ -1,5 +1,0 @@
-@remove {
-    this should be gone
-} @remove
-
-hello world

--- a/test_dir/test1
+++ b/test_dir/test1
@@ -1,0 +1,5 @@
+@remove {
+    this should be gone
+} @remove
+
+hello world

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
 
     /* Basic Options */
     // "incremental": true,                         /* Enable incremental compilation */
-    "target": "es5",                                /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "target": "es2017",                                /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs",                           /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     // "lib": [],                                   /* Specify library files to be included in the compilation. */
     // "allowJs": true,                             /* Allow javascript files to be compiled. */


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Bootsrap CLI - POC of scrubber](https://www.notion.so/uwblueprintexecs/Task-Board-db95cd7b93f245f78ee85e3a8a6a316d?p=b026f45f4cf0469484610a60dcacdcef)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Implement scrubber tool that allows for removing lines in between configurable tags
- Current tool operates on all files in specified directories
- Opening tag spec: tag-name {
- Closing tag spec: } tag-name

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Open `test` file in `scrubber/test_dir/` and verify lines to be removed
2. Run `yarn dev`
3. Verify lines in between tags have been removed

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- scrubber.ts
- scrubberConfig.json

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
