### PR TITLE
Unify CLI and scrubber

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -10,6 +10,7 @@ import {
   APIType,
   BackendType,
   DatabaseType,
+  AuthType,
 } from "./optionTypes";
 
 type CommandLineArgs = Array<string>;
@@ -109,7 +110,7 @@ const parseArguments = (args: CommandLineArgs): CommandLineOptions => {
 
   return {
     backend: argv.backend as BackendType,
-    api: argv.backend as APIType,
+    api: argv.api as APIType,
     database: argv.database as DatabaseType,
     auth: argv.auth,
   };
@@ -168,8 +169,7 @@ const promptOptions = async (options: CommandLineOptions) => {
     backend: options.backend || answers.backend,
     api: options.api || answers.api,
     database: options.database || answers.database,
-    auth: options.auth || answers.auth,
-    output: options.output || answers.output,
+    auth: (options.auth || answers.auth ? "auth" : null) as AuthType,
   };
 };
 

--- a/cli/optionTypes.ts
+++ b/cli/optionTypes.ts
@@ -1,0 +1,19 @@
+export type BackendType = "python" | "typescript";
+
+export type APIType = "rest" | "graphql";
+
+export type DatabaseType = "postgresql" | "mongodb";
+
+export type Options = {
+  backend: BackendType;
+  api: APIType;
+  database: DatabaseType;
+  auth: boolean;
+};
+
+export type CommandLineOptions = {
+  backend?: BackendType;
+  api?: APIType;
+  database?: DatabaseType;
+  auth?: boolean;
+};

--- a/cli/optionTypes.ts
+++ b/cli/optionTypes.ts
@@ -18,4 +18,10 @@ export type CommandLineOptions = {
   api?: APIType;
   database?: DatabaseType;
   auth?: boolean;
+  outputDir?: string;
+};
+
+export type UserResponse = {
+  appOptions: Options;
+  outputDir: string;
 };

--- a/cli/optionTypes.ts
+++ b/cli/optionTypes.ts
@@ -4,11 +4,13 @@ export type APIType = "rest" | "graphql";
 
 export type DatabaseType = "postgresql" | "mongodb";
 
+export type AuthType = "auth";
+
 export type Options = {
   backend: BackendType;
   api: APIType;
   database: DatabaseType;
-  auth: boolean;
+  auth?: AuthType;
 };
 
 export type CommandLineOptions = {

--- a/index.ts
+++ b/index.ts
@@ -4,11 +4,11 @@ import { Options } from "./cli/optionTypes";
 
 import Scrubber from "./scrubber/scrubber";
 
-async function scrub(options: Options) {
+async function scrub(rootDir: string, options: Options) {
   try {
     const scrubber = new Scrubber();
 
-    await scrubber.parseConfig("scrubber/scrubberConfig.json");
+    await scrubber.parseConfig(`${rootDir}/scrubber/scrubberConfig.json`);
     await scrubber.start(options);
   } catch (err) {
     console.log(err);
@@ -16,9 +16,10 @@ async function scrub(options: Options) {
 }
 
 async function run() {
+  const rootDir = __dirname;
   const options = await cli(process.argv);
   if (options) {
-    scrub(options);
+    await scrub(rootDir, options);
   }
 }
 

--- a/index.ts
+++ b/index.ts
@@ -1,20 +1,23 @@
 #!/usr/bin/env node
 import cli from "./cli";
+import { Options } from "./cli/optionTypes";
 
 import Scrubber from "./scrubber/scrubber";
-import { ScrubberAction } from "./scrubber/scrubberTypes";
 
-async function scrub() {
+async function scrub(options: Options) {
   try {
-    const actions: ScrubberAction[] = [{ type: "remove", tags: ["@remove"] }];
     const scrubber = new Scrubber();
 
     await scrubber.parseConfig("scrubber/scrubberConfig.json");
-    await scrubber.start(actions);
+    await scrubber.start(options);
   } catch (err) {
     console.log(err);
   }
 }
 
-cli(process.argv);
-scrub();
+async function run() {
+  const options = await cli(process.argv);
+  scrub(options);
+}
+
+run();

--- a/index.ts
+++ b/index.ts
@@ -17,7 +17,9 @@ async function scrub(options: Options) {
 
 async function run() {
   const options = await cli(process.argv);
-  scrub(options);
+  if (options) {
+    scrub(options);
+  }
 }
 
 run();

--- a/package.json
+++ b/package.json
@@ -34,9 +34,12 @@
     "boxen": "^5.0.0",
     "chalk": "^4.1.0",
     "figlet": "^1.5.0",
+    "glob": "^7.1.6",
     "inquirer": "^8.0.0",
     "shelljs": "^0.8.4",
     "yargs": "^16.2.0"
   },
-  "files": ["bin/"]
+  "files": [
+    "bin/"
+  ]
 }

--- a/scrubber/scrubUtils.ts
+++ b/scrubber/scrubUtils.ts
@@ -12,7 +12,9 @@ const FILE_TYPE_COMMENT: { [key: string]: string } = {
   py: "#",
 };
 
-export function getAllTags(cliOptions: CLIOptionActions): TagNameToAction {
+export function getAllTagsAndSetToRemove(
+  cliOptions: CLIOptionActions,
+): TagNameToAction {
   const tags: TagNameToAction = {};
   Object.values(cliOptions).forEach((option) => {
     option.tagsToKeep?.forEach((tag) => {

--- a/scrubber/scrubber.ts
+++ b/scrubber/scrubber.ts
@@ -31,6 +31,7 @@ class Scrubber {
     const tags = { ...this.tags };
     const filesToDelete = new Set<string>();
 
+    // Set the tags to keep and which files to delete based on selected technologies.
     Object.values(options).forEach((val) => {
       if (!this.config || !val) return;
 
@@ -40,7 +41,7 @@ class Scrubber {
         filesToDelete.add(filename);
       });
 
-      action.tagsToKeep?.forEach((tag) => {
+      action.tagsToKeep?.forEach((tag: string) => {
         tags[tag] = "keep";
       });
     });

--- a/scrubber/scrubber.ts
+++ b/scrubber/scrubber.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import { Options } from "../cli/optionTypes";
-import { ScrubberConfig, TagNameToAction, CLIOption } from "./scrubberTypes";
-import { getAllTags, scrubDir, removeFile } from "./scrubUtils";
+import { ScrubberConfig, TagNameToAction } from "./scrubberTypes";
+import { getAllTagsAndSetToRemove, scrubDir, removeFile } from "./scrubUtils";
 
 async function getConfigFile(filename: string): Promise<ScrubberConfig> {
   try {
@@ -21,7 +21,7 @@ class Scrubber {
   async parseConfig(filename: string) {
     // TODO validate config (e.g.properly formed tag names)
     this.config = await getConfigFile(filename);
-    this.tags = getAllTags(this.config.cliOptionsToActions);
+    this.tags = getAllTagsAndSetToRemove(this.config.cliOptionsToActions);
   }
 
   // Scrub files
@@ -32,18 +32,9 @@ class Scrubber {
     const filesToDelete = new Set<string>();
 
     Object.values(options).forEach((val) => {
-      if (!this.config) return;
+      if (!this.config || !val) return;
 
-      let option: CLIOption;
-
-      if (typeof val === "boolean") {
-        if (!val) return;
-        option = "auth";
-      } else {
-        option = val;
-      }
-
-      const action = this.config.cliOptionsToActions[option];
+      const action = this.config.cliOptionsToActions[val];
 
       action.filesToDelete?.forEach((filename: string) => {
         filesToDelete.add(filename);

--- a/scrubber/scrubberConfig.json
+++ b/scrubber/scrubberConfig.json
@@ -2,11 +2,11 @@
   "cliOptionsToActions": {
     "typescript": {
       "tagsToKeep": ["typescript"],
-      "filesToDelete": ["test_dir/python"]
+      "filesToDelete": ["python/"]
     },
     "python": {
       "tagsToKeep": ["python"],
-      "filesToDelete": ["typescript"]
+      "filesToDelete": ["typescript/"]
     },
     "rest": {
       "tagsToKeep": ["rest"]
@@ -24,5 +24,6 @@
       "tagsToKeep": ["auth"]
     }
   },
-  "dirs": ["test_dir"]
+  "dir": "starter-code-v2",
+  "ignore": ["node_modules", ".git", "yarn.lock"]
 }

--- a/scrubber/scrubberConfig.json
+++ b/scrubber/scrubberConfig.json
@@ -1,9 +1,28 @@
 {
-  "actions": [
-    {
-      "type": "keep",
-      "tags": ["@remove", "@remove2"]
+  "cliOptionsToActions": {
+    "typescript": {
+      "tagsToKeep": ["typescript"],
+      "filesToDelete": ["test_dir/python"]
+    },
+    "python": {
+      "tagsToKeep": ["python"],
+      "filesToDelete": ["typescript"]
+    },
+    "rest": {
+      "tagsToKeep": ["rest"]
+    },
+    "graphql": {
+      "tagsToKeep": ["graphql"]
+    },
+    "postgresql": {
+      "tagsToKeep": ["postgresql"]
+    },
+    "mongodb": {
+      "tagsToKeep": ["mongodb"]
+    },
+    "auth": {
+      "tagsToKeep": ["auth"]
     }
-  ],
+  },
   "dirs": ["test_dir"]
 }

--- a/scrubber/scrubberTypes.ts
+++ b/scrubber/scrubberTypes.ts
@@ -2,6 +2,8 @@
 Types required by the scrubber tool.
 */
 
+import { BackendType, APIType, DatabaseType } from "../cli/optionTypes";
+
 export type ScrubberActionType = "remove" | "keep";
 
 export type ScrubberAction = {
@@ -9,8 +11,17 @@ export type ScrubberAction = {
   tags: string[];
 };
 
+export type CLIOption = BackendType | APIType | DatabaseType | "auth";
+
+export type CLIOptionActions = {
+  [key in CLIOption]: {
+    tagsToKeep?: string[];
+    filesToDelete?: string[];
+  };
+};
+
 export type ScrubberConfig = {
-  actions: ScrubberAction[];
+  cliOptionsToActions: CLIOptionActions;
   dirs: string[];
 };
 

--- a/scrubber/scrubberTypes.ts
+++ b/scrubber/scrubberTypes.ts
@@ -22,7 +22,8 @@ export type CLIOptionActions = {
 
 export type ScrubberConfig = {
   cliOptionsToActions: CLIOptionActions;
-  dirs: string[];
+  dir: string; // Directories to operate on (relative path).
+  ignore: string[]; // Directory and file names to ignore.
 };
 
 export type TagNameToAction = { [key: string]: ScrubberActionType };

--- a/test_dir/test
+++ b/test_dir/test
@@ -1,5 +1,9 @@
-@remove {
-    this should be gone
-} @remove
+mongodb {
+    this should be deleted
+} mongodb
 
 hello world
+
+postgresql {
+    this is postgresql
+} postgresql

--- a/test_dir/test.js
+++ b/test_dir/test.js
@@ -1,5 +1,5 @@
-// @remove {
+// typescript {
 console.log("this should be gone");
-// } @remove
+// } typescript
 
 console.log("hello world");

--- a/test_dir/test.py
+++ b/test_dir/test.py
@@ -1,5 +1,9 @@
-# @remove {
+# python {
     print('this should be gone')
-# } @remove
+# } python
 
-print('hello world')
+print('hello world')e
+
+# auth {
+    print("auth features here")
+# } auth

--- a/yarn.lock
+++ b/yarn.lock
@@ -902,7 +902,7 @@ glob-parent@^5.0.0, glob-parent@^5.1.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob@^7.0.0, glob@^7.1.3:
+glob@^7.0.0, glob@^7.1.3, glob@^7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==


### PR DESCRIPTION
Co-authored-by: Alex Guo <guozalex@gmail.com>

## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Tie CLI together with scrubber and use on starter-code-v2 repo](https://www.notion.so/uwblueprintexecs/Task-Board-db95cd7b93f245f78ee85e3a8a6a316d?p=6aefbfb3c7334561a0b2ffbc4c6e3092)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Fixed types for CLI
- Passed CLI options to scrubber which configures tags and filesToDelete
- Scrubber uses a dict tags that maps tag name to action ("keep" or "remove")
- Scrubber uses an array filesToDelete that deletes certain files


<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Run yarn dev and go through the CLI
2. Verify that the corresponding files/directories are deleted (if you picked typescript, python folder would get deleted)
3. Verify that the chosen tags are kept and all other tags are deleted

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- start function in scrubber
- config structure

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
