### PR TITLE
Prevent graphql python combination

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -9,6 +9,7 @@ import {
   APIType,
   BackendType,
   DatabaseType,
+  AuthType,
 } from "./optionTypes";
 
 type CommandLineArgs = Array<string>;
@@ -97,7 +98,7 @@ const parseArguments = (args: CommandLineArgs): CommandLineOptions => {
 
   return {
     backend: argv.backend as BackendType,
-    api: argv.backend as APIType,
+    api: argv.api as APIType,
     database: argv.database as DatabaseType,
     auth: argv.auth,
   };
@@ -147,7 +148,7 @@ const promptOptions = async (options: CommandLineOptions) => {
     backend: options.backend || answers.backend,
     api: options.api || answers.api,
     database: options.database || answers.database,
-    auth: options.auth || answers.auth,
+    auth: (options.auth || answers.auth ? "auth" : null) as AuthType,
   };
 };
 

--- a/cli/optionTypes.ts
+++ b/cli/optionTypes.ts
@@ -1,0 +1,19 @@
+export type BackendType = "python" | "typescript";
+
+export type APIType = "rest" | "graphql";
+
+export type DatabaseType = "postgresql" | "mongodb";
+
+export type Options = {
+  backend: BackendType;
+  api: APIType;
+  database: DatabaseType;
+  auth: boolean;
+};
+
+export type CommandLineOptions = {
+  backend?: BackendType;
+  api?: APIType;
+  database?: DatabaseType;
+  auth?: boolean;
+};

--- a/cli/optionTypes.ts
+++ b/cli/optionTypes.ts
@@ -4,11 +4,13 @@ export type APIType = "rest" | "graphql";
 
 export type DatabaseType = "postgresql" | "mongodb";
 
+export type AuthType = "auth";
+
 export type Options = {
   backend: BackendType;
   api: APIType;
   database: DatabaseType;
-  auth: boolean;
+  auth?: AuthType;
 };
 
 export type CommandLineOptions = {

--- a/index.ts
+++ b/index.ts
@@ -1,20 +1,23 @@
 #!/usr/bin/env node
 import cli from "./cli";
+import { Options } from "./cli/optionTypes";
 
 import Scrubber from "./scrubber/scrubber";
-import { ScrubberAction } from "./scrubber/scrubberTypes";
 
-async function scrub() {
+async function scrub(options: Options) {
   try {
-    const actions: ScrubberAction[] = [{ type: "remove", tags: ["@remove"] }];
     const scrubber = new Scrubber();
 
     await scrubber.parseConfig("scrubber/scrubberConfig.json");
-    await scrubber.start(actions);
+    await scrubber.start(options);
   } catch (err) {
     console.log(err);
   }
 }
 
-cli(process.argv);
-scrub();
+async function run() {
+  const options = await cli(process.argv);
+  scrub(options);
+}
+
+run();

--- a/index.ts
+++ b/index.ts
@@ -16,8 +16,12 @@ async function scrub(options: Options) {
 }
 
 async function run() {
-  const options = await cli(process.argv);
-  scrub(options);
+  try {
+    const options = await cli(process.argv);
+    scrub(options);
+  } catch (err) {
+    console.log(err);
+  }
 }
 
 run();

--- a/scrubber/scrubUtils.ts
+++ b/scrubber/scrubUtils.ts
@@ -12,7 +12,9 @@ const FILE_TYPE_COMMENT: { [key: string]: string } = {
   py: "#",
 };
 
-export function getAllTags(cliOptions: CLIOptionActions): TagNameToAction {
+export function getAllTagsAndSetToRemove(
+  cliOptions: CLIOptionActions,
+): TagNameToAction {
   const tags: TagNameToAction = {};
   Object.values(cliOptions).forEach((option) => {
     option.tagsToKeep?.forEach((tag) => {

--- a/scrubber/scrubUtils.ts
+++ b/scrubber/scrubUtils.ts
@@ -1,0 +1,143 @@
+import fs from "fs";
+import path from "path";
+import { ScrubberAction, TagNameToAction } from "./scrubberTypes";
+
+const TAG_START_CHAR = "{";
+const TAG_END_CHAR = "}";
+
+const FILE_TYPE_COMMENT: { [key: string]: string } = {
+  js: "//",
+  json: "//",
+  ts: "//",
+  py: "#",
+};
+
+export function scrubberActionsToDict(
+  actions: ScrubberAction[],
+): TagNameToAction {
+  const dict: TagNameToAction = {};
+  actions.forEach((action) => {
+    action.tags.forEach((tag: string) => {
+      dict[tag] = action.type;
+    });
+  });
+  return dict;
+}
+
+export async function scrubFile(
+  filePath: string,
+  tags: TagNameToAction,
+  isDryRun: boolean,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    fs.readFile(filePath, { encoding: "utf8" }, async (err, text) => {
+      if (err) {
+        reject(err);
+      }
+
+      const ext = filePath.split(".").pop();
+      const commentType = ext && FILE_TYPE_COMMENT[ext];
+      const scrubbedLines: string[] = [];
+      let skip = false;
+
+      const lines: string[] = text.split("\n");
+
+      for (let i = 0; i < lines.length; ++i) {
+        const line = lines[i];
+        let tryProcessTag = true;
+
+        if (line.length === 0) {
+          scrubbedLines.push(line);
+          continue;
+        }
+
+        // Split on whitespace
+        const tokens = line.trim().split(/[ ]+/);
+
+        if (commentType) {
+          if (tokens[0] !== commentType) {
+            tryProcessTag = false;
+          }
+          tokens.shift();
+        }
+
+        if (tryProcessTag) {
+          if (tokens[0] in tags && tokens.length !== 2) {
+            console.warn(
+              `WARNING line ${
+                i + 1
+              }: possible malformed tag; tags must be on their own line preceded by '}' or followed by '{'`,
+            );
+            scrubbedLines.push(line);
+            continue;
+          }
+
+          if (tokens[0] in tags || tokens[1] in tags) {
+            const tag = tokens[0] in tags ? tokens[0] : tokens[1];
+            const brace = tag === tokens[0] ? tokens[1] : tokens[0];
+
+            if (brace === tokens[1] && brace !== TAG_START_CHAR) {
+              throw new Error(
+                `Malformed tag ${filePath}:line ${
+                  i + 1
+                }: expected '{' after tag name`,
+              );
+            }
+
+            if (brace === tokens[0] && brace !== TAG_END_CHAR) {
+              throw new Error(
+                `Malformed tag ${filePath}:line ${
+                  i + 1
+                }: expected '}' before tag name`,
+              );
+            }
+
+            // NOTE: nested tagging is not currently supported and will lead to unexpected behaviour.
+
+            if (tags[tag] === "remove") {
+              skip = brace === TAG_START_CHAR;
+            }
+
+            // We always scrub tags from the final file.
+            continue;
+          }
+        }
+
+        if (skip) {
+          if (isDryRun) {
+            console.log(`Skipping line ${i + 1}`);
+          }
+          continue;
+        }
+
+        scrubbedLines.push(line);
+      }
+
+      if (isDryRun) return;
+
+      fs.writeFileSync(filePath, scrubbedLines.join("\n"));
+
+      resolve();
+    });
+  });
+}
+
+export async function scrubDir(
+  dir: string,
+  tags: TagNameToAction,
+  isDryRun: boolean,
+): Promise<void[]> {
+  const files = fs.readdirSync(dir);
+  const promises = files.map<Promise<any>>((name: string) => {
+    const filePath = path.join(dir, name);
+    const stat = fs.statSync(filePath);
+    if (stat.isFile()) {
+      return scrubFile(filePath, tags, isDryRun);
+    }
+    if (stat.isDirectory()) {
+      return scrubDir(filePath, tags, isDryRun);
+    }
+    return Promise.resolve();
+  });
+  return Promise.all(promises);
+}

--- a/scrubber/scrubber.ts
+++ b/scrubber/scrubber.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import { Options } from "../cli/optionTypes";
-import { ScrubberConfig, TagNameToAction, CLIOption } from "./scrubberTypes";
-import { getAllTags, scrubDir, removeFile } from "./scrubUtils";
+import { ScrubberConfig, TagNameToAction } from "./scrubberTypes";
+import { getAllTagsAndSetToRemove, scrubDir, removeFile } from "./scrubUtils";
 
 async function getConfigFile(filename: string): Promise<ScrubberConfig> {
   try {
@@ -21,7 +21,7 @@ class Scrubber {
   async parseConfig(filename: string) {
     // TODO validate config (e.g.properly formed tag names)
     this.config = await getConfigFile(filename);
-    this.tags = getAllTags(this.config.cliOptionsToActions);
+    this.tags = getAllTagsAndSetToRemove(this.config.cliOptionsToActions);
   }
 
   // Scrub files
@@ -32,18 +32,9 @@ class Scrubber {
     const filesToDelete = new Set<string>();
 
     Object.values(options).forEach((val) => {
-      if (!this.config) return;
+      if (!this.config || !val) return;
 
-      let option: CLIOption;
-
-      if (typeof val === "boolean") {
-        if (!val) return;
-        option = "auth";
-      } else {
-        option = val;
-      }
-
-      const action = this.config.cliOptionsToActions[option];
+      const action = this.config.cliOptionsToActions[val];
 
       action.filesToDelete?.forEach((filename: string) => {
         filesToDelete.add(filename);

--- a/scrubber/scrubber.ts
+++ b/scrubber/scrubber.ts
@@ -1,30 +1,10 @@
 import fs from "fs";
-import path from "path";
 import {
   ScrubberAction,
   TagNameToAction,
   ScrubberConfig,
 } from "./scrubberTypes";
-
-const TAG_START_CHAR = "{";
-const TAG_END_CHAR = "}";
-
-const FILE_TYPE_COMMENT: { [key: string]: string } = {
-  js: "//",
-  json: "//",
-  ts: "//",
-  py: "#",
-};
-
-function scrubberActionsToDict(actions: ScrubberAction[]): TagNameToAction {
-  const dict: TagNameToAction = {};
-  actions.forEach((action) => {
-    action.tags.forEach((tag: string) => {
-      dict[tag] = action.type;
-    });
-  });
-  return dict;
-}
+import { scrubberActionsToDict, scrubDir } from "./scrubUtils";
 
 async function getConfigFile(filename: string): Promise<ScrubberConfig> {
   try {
@@ -34,124 +14,6 @@ async function getConfigFile(filename: string): Promise<ScrubberConfig> {
     console.error("Failed to read file ", filename);
     throw err;
   }
-}
-
-async function scrubFile(
-  filePath: string,
-  tags: TagNameToAction,
-  isDryRun: boolean,
-): Promise<void> {
-  return new Promise((resolve, reject) => {
-    fs.readFile(filePath, { encoding: "utf8" }, async (err, text) => {
-      if (err) {
-        reject(err);
-      }
-
-      const ext = filePath.split(".").pop();
-      const commentType = ext && FILE_TYPE_COMMENT[ext];
-      const scrubbedLines: string[] = [];
-      let skip = false;
-
-      const lines: string[] = text.split("\n");
-
-      for (let i = 0; i < lines.length; ++i) {
-        const line = lines[i];
-        let tryProcessTag = true;
-
-        if (line.length === 0) {
-          scrubbedLines.push(line);
-          continue;
-        }
-
-        // Split on whitespace
-        const tokens = line.trim().split(/[ ]+/);
-
-        if (commentType) {
-          if (tokens[0] !== commentType) {
-            tryProcessTag = false;
-          }
-          tokens.shift();
-        }
-
-        if (tryProcessTag) {
-          if (tokens[0] in tags && tokens.length !== 2) {
-            console.warn(
-              `WARNING line ${
-                i + 1
-              }: possible malformed tag; tags must be on their own line preceded by '}' or followed by '{'`,
-            );
-            scrubbedLines.push(line);
-            continue;
-          }
-
-          if (tokens[0] in tags || tokens[1] in tags) {
-            const tag = tokens[0] in tags ? tokens[0] : tokens[1];
-            const brace = tag === tokens[0] ? tokens[1] : tokens[0];
-
-            if (brace === tokens[1] && brace !== TAG_START_CHAR) {
-              throw new Error(
-                `Malformed tag ${filePath}:line ${
-                  i + 1
-                }: expected '{' after tag name`,
-              );
-            }
-
-            if (brace === tokens[0] && brace !== TAG_END_CHAR) {
-              throw new Error(
-                `Malformed tag ${filePath}:line ${
-                  i + 1
-                }: expected '}' before tag name`,
-              );
-            }
-
-            // NOTE: nested tagging is not currently expected and will lead to unexpected behaviour.
-
-            if (tags[tag] === "remove") {
-              skip = brace === TAG_START_CHAR;
-            }
-
-            // We always scrub tags from the final file.
-            continue;
-          }
-        }
-
-        if (skip) {
-          if (isDryRun) {
-            console.log(`Skipping line ${i + 1}`);
-          }
-          continue;
-        }
-
-        scrubbedLines.push(line);
-      }
-
-      if (isDryRun) return;
-
-      fs.writeFileSync(filePath, scrubbedLines.join("\n"));
-
-      resolve();
-    });
-  });
-}
-
-async function scrubDir(
-  dir: string,
-  tags: TagNameToAction,
-  isDryRun: boolean,
-): Promise<void[]> {
-  const files = fs.readdirSync(dir);
-  const promises = files.map<Promise<any>>((name: string) => {
-    const filePath = path.join(dir, name);
-    const stat = fs.statSync(filePath);
-    if (stat.isFile()) {
-      return scrubFile(filePath, tags, isDryRun);
-    }
-    if (stat.isDirectory()) {
-      return scrubDir(filePath, tags, isDryRun);
-    }
-    return Promise.resolve();
-  });
-  return Promise.all(promises);
 }
 
 class Scrubber {

--- a/scrubber/scrubberConfig.json
+++ b/scrubber/scrubberConfig.json
@@ -1,9 +1,28 @@
 {
-  "actions": [
-    {
-      "type": "keep",
-      "tags": ["@remove", "@remove2"]
+  "cliOptionsToActions": {
+    "typescript": {
+      "tagsToKeep": ["typescript"],
+      "filesToDelete": ["test_dir/python"]
+    },
+    "python": {
+      "tagsToKeep": ["python"],
+      "filesToDelete": ["typescript"]
+    },
+    "rest": {
+      "tagsToKeep": ["rest"]
+    },
+    "graphql": {
+      "tagsToKeep": ["graphql"]
+    },
+    "postgresql": {
+      "tagsToKeep": ["postgresql"]
+    },
+    "mongodb": {
+      "tagsToKeep": ["mongodb"]
+    },
+    "auth": {
+      "tagsToKeep": ["auth"]
     }
-  ],
+  },
   "dirs": ["test_dir"]
 }

--- a/scrubber/scrubberTypes.ts
+++ b/scrubber/scrubberTypes.ts
@@ -2,6 +2,8 @@
 Types required by the scrubber tool.
 */
 
+import { BackendType, APIType, DatabaseType } from "../cli/optionTypes";
+
 export type ScrubberActionType = "remove" | "keep";
 
 export type ScrubberAction = {
@@ -9,8 +11,17 @@ export type ScrubberAction = {
   tags: string[];
 };
 
+export type CLIOption = BackendType | APIType | DatabaseType | "auth";
+
+export type CLIOptionActions = {
+  [key in CLIOption]: {
+    tagsToKeep?: string[];
+    filesToDelete?: string[];
+  };
+};
+
 export type ScrubberConfig = {
-  actions: ScrubberAction[];
+  cliOptionsToActions: CLIOptionActions;
   dirs: string[];
 };
 

--- a/test_dir/test
+++ b/test_dir/test
@@ -1,5 +1,9 @@
-@remove {
-    this should be gone
-} @remove
+mongodb {
+    this should be deleted
+} mongodb
 
 hello world
+
+postgresql {
+    this is postgresql
+} postgresql

--- a/test_dir/test.js
+++ b/test_dir/test.js
@@ -1,5 +1,5 @@
-// @remove {
+// typescript {
 console.log("this should be gone");
-// } @remove
+// } typescript
 
 console.log("hello world");

--- a/test_dir/test.py
+++ b/test_dir/test.py
@@ -1,5 +1,9 @@
-# @remove {
+# python {
     print('this should be gone')
-# } @remove
+# } python
 
-print('hello world')
+print('hello world')e
+
+# auth {
+    print("auth features here")
+# } auth


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Remove GraphQL option if Python chosen as backend](https://www.notion.so/uwblueprintexecs/Task-Board-db95cd7b93f245f78ee85e3a8a6a316d?p=123445430fcd43ebb1d5273b7fbdeda7)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Prevent users from picking graphql if they chose python as their language
- In case users bypass prompts with command line options, prevent them from proceeding

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

<img width="818" alt="image" src="https://user-images.githubusercontent.com/37782734/114956302-975aec00-9e2c-11eb-917f-b23da2210f08.png">
<img width="824" alt="image" src="https://user-images.githubusercontent.com/37782734/114956329-a6419e80-9e2c-11eb-90dc-1615d1cb52b3.png">


## Steps to test

1. Run npm run prod -- -a graphql and pick python as the language. Verify that it does not let you proceed.
2. Run npm run prod and pick typescript. Verify that it does not let you select graphql.

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Is there a cleaner way to accomplish this?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
