### PR TITLE
Remove .git after cloning starter code

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -295,6 +295,13 @@ async function cli(args: CommandLineArgs): Promise<Options> {
     return Promise.reject(new Error("Git clone failed. Exiting..."));
   }
 
+  console.log(chalk.green.bold("Removing .git ..."));
+  const removeGit = shell.exec("rm -rf starter-code-v2/.git");
+
+  if (removeGit.code !== 0) {
+    return Promise.reject(new Error("Remove .git failed. Exiting..."));
+  }
+
   return appOptions;
 }
 


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Remove .git directory in cloned starter-code-v2 repo](https://www.notion.so/uwblueprintexecs/Task-Board-db95cd7b93f245f78ee85e3a8a6a316d?p=5eb2b1218e2a4ca7bde5324c13ac180d)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Remove .git using shelljs after cloning starter code

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Run npm run prod
2. Verify that there is not .git folder after cloning starter code

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

-

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
