### PR TITLE
Prevent graphql and python combination

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import chalk from "chalk";
 import cli from "./cli";
 import { Options } from "./cli/optionTypes";
 
@@ -21,7 +22,7 @@ async function run() {
     const options = await cli(process.argv);
     await scrub(rootDir, options);
   } catch (err) {
-    console.log(err);
+    console.log(chalk.red.bold(err.message));
   }
 }
 

--- a/index.ts
+++ b/index.ts
@@ -17,9 +17,11 @@ async function scrub(rootDir: string, options: Options) {
 
 async function run() {
   const rootDir = __dirname;
-  const options = await cli(process.argv);
-  if (options) {
+  try {
+    const options = await cli(process.argv);
     await scrub(rootDir, options);
+  } catch (err) {
+    console.log(err);
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "license": "MIT",
   "scripts": {
     "dev": "ts-node index.ts",
-    "lint": "eslint . --ext .ts,.js",
-    "lint-fix": "eslint . --ext .ts,.js --fix",
+    "lint": "eslint . --ext .ts",
+    "lint-fix": "eslint . --ext .ts --fix",
     "prod": "tsc -p . && node bin/index.js"
   },
   "devDependencies": {


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Remove GraphQL option if Python chosen as backend](https://www.notion.so/uwblueprintexecs/Task-Board-db95cd7b93f245f78ee85e3a8a6a316d?p=123445430fcd43ebb1d5273b7fbdeda7)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Prevent users from picking graphql if they chose python as their language
- In case users bypass prompts with command line options, prevent them from proceeding

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

<img width="818" alt="image" src="https://user-images.githubusercontent.com/37782734/114956302-975aec00-9e2c-11eb-917f-b23da2210f08.png">
<img width="824" alt="image" src="https://user-images.githubusercontent.com/37782734/114956329-a6419e80-9e2c-11eb-90dc-1615d1cb52b3.png">


## Steps to test

1. Run npm run prod -- -a graphql and pick python as the language. Verify that it does not let you proceed.
2. Run npm run prod and pick typescript. Verify that it does not let you select graphql.

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Is there a cleaner way to accomplish this?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
