### PR TITLE
Add local testing command line argument

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -24,7 +24,7 @@ type Choice<T> = {
 type OptionConfig<T> = {
   id: string;
   description: string;
-  message: string;
+  message?: string;
   choices: ReadonlyArray<Choice<T>>;
 };
 
@@ -34,6 +34,7 @@ type OptionConfigs = {
   database: OptionConfig<DatabaseType>;
   auth: OptionConfig<void>;
   outputDir: OptionConfig<void>;
+  testing: OptionConfig<void>;
 };
 
 const OPTIONS: OptionConfigs = {
@@ -75,6 +76,11 @@ const OPTIONS: OptionConfigs = {
     description: "Output directory",
     message:
       "Which directory would you like the starter code folder to be in (default is current directory)?",
+    choices: [],
+  },
+  testing: {
+    id: "t",
+    description: "Test locally without cloning repo",
     choices: [],
   },
 };
@@ -123,7 +129,7 @@ const parseArguments = (args: CommandLineArgs): CommandLineOptions => {
     database: {
       alias: OPTIONS.database.id,
       type: "string",
-      description: OPTIONS.api.description,
+      description: OPTIONS.database.description,
       choices: OPTIONS.database.choices.map((choice) => choice.value),
     },
     auth: {
@@ -136,6 +142,11 @@ const parseArguments = (args: CommandLineArgs): CommandLineOptions => {
       type: "string",
       description: OPTIONS.outputDir.description,
     },
+    testing: {
+      alias: OPTIONS.testing.id,
+      type: "boolean",
+      description: OPTIONS.testing.description,
+    },
   });
 
   return {
@@ -143,6 +154,8 @@ const parseArguments = (args: CommandLineArgs): CommandLineOptions => {
     api: argv.api as APIType,
     database: argv.database as DatabaseType,
     auth: argv.auth,
+    outputDir: argv.outputDir,
+    testing: argv.testing,
   };
 };
 
@@ -287,19 +300,21 @@ async function cli(args: CommandLineArgs): Promise<Options> {
     return Promise.reject(new Error("No directory exists. Exiting..."));
   }
 
-  const clone = shell.exec(
-    "git clone https://github.com/uwblueprint/starter-code-v2.git",
-  );
+  if (!commandLineOptions.testing) {
+    const clone = shell.exec(
+      "git clone https://github.com/uwblueprint/starter-code-v2.git",
+    );
 
-  if (clone.code !== 0) {
-    return Promise.reject(new Error("Git clone failed. Exiting..."));
-  }
+    if (clone.code !== 0) {
+      return Promise.reject(new Error("Git clone failed. Exiting..."));
+    }
 
-  console.log(chalk.green.bold("Removing .git ..."));
-  const removeGit = shell.exec("rm -rf starter-code-v2/.git");
+    console.log(chalk.green.bold("Removing .git ..."));
+    const removeGit = shell.exec("rm -rf starter-code-v2/.git");
 
-  if (removeGit.code !== 0) {
-    return Promise.reject(new Error("Remove .git failed. Exiting..."));
+    if (removeGit.code !== 0) {
+      return Promise.reject(new Error("Remove .git failed. Exiting..."));
+    }
   }
 
   return appOptions;

--- a/cli/optionTypes.ts
+++ b/cli/optionTypes.ts
@@ -19,6 +19,7 @@ export type CommandLineOptions = {
   database?: DatabaseType;
   auth?: boolean;
   outputDir?: string;
+  testing?: boolean;
 };
 
 export type UserResponse = {

--- a/scrubber/scrubberConfig.json
+++ b/scrubber/scrubberConfig.json
@@ -2,11 +2,11 @@
   "cliOptionsToActions": {
     "typescript": {
       "tagsToKeep": ["typescript"],
-      "filesToDelete": ["python/"]
+      "filesToDelete": ["backend/python/"]
     },
     "python": {
       "tagsToKeep": ["python"],
-      "filesToDelete": ["typescript/"]
+      "filesToDelete": ["backend/typescript/"]
     },
     "rest": {
       "tagsToKeep": ["rest"]


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Add option to pass in directory as argument for testing](https://www.notion.so/uwblueprintexecs/Task-Board-db95cd7b93f245f78ee85e3a8a6a316d?p=8ba19a5c68d54005a26828925b7e52a1)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Add command line argument for testing locally (which doesn't git clone the repo)
- Use the outputDir command line argument to specify relative path of local repo to scrub

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Run npm run dev -- --testing
2. Verify that the scrubber is only called on the local repo and doesn't use git clone.

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

-

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
