### PR TITLE
Remove Default page as fileToDelete for no-auth and silence warnings in prod

### DIFF
--- a/scrubber/scrubUtils.ts
+++ b/scrubber/scrubUtils.ts
@@ -67,13 +67,15 @@ export function scrubFile(
 
         if (tryProcessTag) {
           if (tokens[0] in tags && tokens.length !== 2) {
-            console.warn(
-              chalk.yellowBright.bold(
-                `WARNING line ${
-                  i + 1
-                }: possible malformed tag; tags must be on their own line preceded by '}' or followed by '{'`,
-              ),
-            );
+            if (process.env.NODE_ENV !== "production") {
+              console.warn(
+                chalk.yellowBright.bold(
+                  `WARNING line ${
+                    i + 1
+                  }: possible malformed tag; tags must be on their own line preceded by '}' or followed by '{'`,
+                ),
+              );
+            }
             scrubbedLines.push(line);
             continue;
           }

--- a/scrubber/scrubberConfig.json
+++ b/scrubber/scrubberConfig.json
@@ -55,7 +55,6 @@
         "backend/python/app/utilities/firebase_rest_client.py",
         "frontend/src/APIClients/AuthAPIClient.ts",
         "frontend/src/components/auth",
-        "frontend/src/components/pages/Default.tsx",
         "frontend/src/constants/AuthConstants.ts",
         "frontend/src/contexts/AuthContext.ts"
       ]


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

N/A - quick fix

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Removed Default page as a fileToDelete for `no-auth`
- Silence possible malformed tag warnings in prod

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Run the CLI as usual (should allow testing of all entity CRU functionality in the frontend)

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
