### PR TITLE
Update package version to match npm registry and edit PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,3 +28,4 @@
 - [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
 - [ ] I have run the appropriate linter(s)
 - [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
+- [ ] I have updated the version number in `package.json` according to Semantic Versioning specs ([semver](https://semver.org)) if I will be publishing these changes to the npm registry

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uwblueprint/create-bp-app",
-  "version": "1.0.3",
+  "version": "1.0.7",
   "description": "Starter code generation CLI tool.",
   "main": "index.js",
   "bin": "bin/index.js",


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

N/A

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Some version increments made when publishing to npm were not checked into git, this PR just catches up the version number in package.json to the one in the npm registry (v1.0.7)
- Added checklist step in PR template to enforce version number increment if changes will be published

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

N/A

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
