### PR TITLE
Add file storage and csv export options to CLI

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -12,6 +12,8 @@ import {
   BackendType,
   DatabaseType,
   AuthType,
+  FileStorageType,
+  CSVExportType,
 } from "./optionTypes";
 
 type CommandLineArgs = Array<string>;
@@ -33,6 +35,8 @@ type OptionConfigs = {
   api: OptionConfig<APIType>;
   database: OptionConfig<DatabaseType>;
   auth: OptionConfig<void>;
+  fileStorage: OptionConfig<void>;
+  csvExport: OptionConfig<void>;
   outputDir: OptionConfig<void>;
   testing: OptionConfig<void>;
 };
@@ -69,6 +73,18 @@ const OPTIONS: OptionConfigs = {
     id: "au",
     description: "Include built-in auth features",
     message: "Would you like built-in auth features?",
+    choices: [],
+  },
+  fileStorage: {
+    id: "f",
+    description: "Include built-in file storage features",
+    message: "Would you like built-in file storage features?",
+    choices: [],
+  },
+  csvExport: {
+    id: "c",
+    description: "Include built-in csv export features",
+    message: "Would you like built-in csv export features?",
     choices: [],
   },
   outputDir: {
@@ -137,6 +153,16 @@ const parseArguments = (args: CommandLineArgs): CommandLineOptions => {
       type: "boolean",
       description: OPTIONS.auth.description,
     },
+    fileStorage: {
+      alias: OPTIONS.fileStorage.id,
+      type: "boolean",
+      description: OPTIONS.fileStorage.description,
+    },
+    csvExport: {
+      alias: OPTIONS.csvExport.id,
+      type: "boolean",
+      description: OPTIONS.csvExport.description,
+    },
     outputDir: {
       alias: OPTIONS.outputDir.id,
       type: "string",
@@ -154,6 +180,8 @@ const parseArguments = (args: CommandLineArgs): CommandLineOptions => {
     api: argv.api as APIType,
     database: argv.database as DatabaseType,
     auth: argv.auth,
+    fileStorage: argv.fileStorage,
+    csvExport: argv.csvExport,
     outputDir: argv.outputDir,
     testing: argv.testing,
   };
@@ -211,6 +239,24 @@ const promptOptions = async (
     });
   }
 
+  if (!options.fileStorage) {
+    prompts.push({
+      type: "confirm",
+      name: "fileStorage",
+      message: OPTIONS.fileStorage.message,
+      default: false,
+    });
+  }
+
+  if (!options.csvExport) {
+    prompts.push({
+      type: "confirm",
+      name: "csvExport",
+      message: OPTIONS.csvExport.message,
+      default: false,
+    });
+  }
+
   if (!options.outputDir) {
     prompts.push({
       type: "output",
@@ -228,6 +274,12 @@ const promptOptions = async (
       api: options.api || answers.api,
       database: options.database || answers.database,
       auth: (options.auth || answers.auth ? "auth" : "no-auth") as AuthType,
+      fileStorage: (options.fileStorage || answers.fileStorage
+        ? "file-storage"
+        : "no-file-storage") as FileStorageType,
+      csvExport: (options.csvExport || answers.csvExport
+        ? "csv-export"
+        : "no-csv-export") as CSVExportType,
     },
     outputDir: options.outputDir || answers.outputDir,
   };
@@ -248,9 +300,13 @@ const confirmPrompt = async (options: Options) => {
 
   const message =
     `You have chosen to create a ${backendName} app with a ` +
-    `${apiName} API, ${databaseName} database, and ${
+    `${apiName} API, ${databaseName} database, ${
       options.auth === "auth" ? "" : "no "
-    }built-in auth. Please confirm:`;
+    }built-in auth, ${
+      options.fileStorage === "file-storage" ? "" : "no "
+    }built-in file storage, and ${
+      options.csvExport === "csv-export" ? "" : "no "
+    }built-in csv export. Please confirm:`;
 
   const prompt = {
     type: "confirm",

--- a/cli/optionTypes.ts
+++ b/cli/optionTypes.ts
@@ -6,11 +6,17 @@ export type DatabaseType = "postgresql" | "mongodb";
 
 export type AuthType = "auth" | "no-auth";
 
+export type FileStorageType = "file-storage" | "no-file-storage";
+
+export type CSVExportType = "csv-export" | "no-csv-export";
+
 export type Options = {
   backend: BackendType;
   api: APIType;
   database: DatabaseType;
   auth: AuthType;
+  fileStorage: FileStorageType;
+  csvExport: CSVExportType;
 };
 
 export type CommandLineOptions = {
@@ -18,6 +24,8 @@ export type CommandLineOptions = {
   api?: APIType;
   database?: DatabaseType;
   auth?: boolean;
+  fileStorage?: boolean;
+  csvExport?: boolean;
   outputDir?: string;
   testing?: boolean;
 };

--- a/scrubber/scrubberConfig.json
+++ b/scrubber/scrubberConfig.json
@@ -61,7 +61,19 @@
         "frontend/src/contexts/AuthContext.ts",
         "frontend/src/utils/LocalStorageUtils.ts"
       ]
-    }
+    },
+    "file-storage": {
+      "tagsToKeep": ["file-storage"]
+    },
+    "no-file-storage": {
+      "tagsToKeep": ["no-file-storage"]
+    },
+    "csv-export": {
+      "tagsToKeep": ["csv-export"]
+    },
+    "no-csv-export": {
+      "tagsToKeep": ["no-csv-export"]
+    },
   },
   "dir": "starter-code-v2",
   "ignore": ["node_modules", ".git", "yarn.lock", "public"]

--- a/scrubber/scrubberTypes.ts
+++ b/scrubber/scrubberTypes.ts
@@ -7,6 +7,8 @@ import {
   APIType,
   DatabaseType,
   AuthType,
+  FileStorageType,
+  CSVExportType,
 } from "../cli/optionTypes";
 
 export type ScrubberActionType = "remove" | "keep";
@@ -16,7 +18,13 @@ export type ScrubberAction = {
   tags: string[];
 };
 
-export type CLIOption = BackendType | APIType | DatabaseType | AuthType;
+export type CLIOption =
+  | BackendType
+  | APIType
+  | DatabaseType
+  | AuthType
+  | FileStorageType
+  | CSVExportType;
 
 export type CLIOptionActions = {
   [key in CLIOption]: {


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

[Add file storage opt in/out option in CLI](https://www.notion.so/uwblueprintexecs/Task-Board-db95cd7b93f245f78ee85e3a8a6a316d?p=2881c4b0b2c344f380efb6b765bdd890)
[Add csv export opt in/out option in CLI](https://www.notion.so/uwblueprintexecs/Task-Board-db95cd7b93f245f78ee85e3a8a6a316d?p=5c335ffef1884bcbbbd13018663d3e00)

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Add boolean prompts similar to auth
- Not publishing these to npm registry since we don't have these options fully implemented in starter code yet

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Comment out `await scrub(rootDir, options);` in root index.ts and add `console.log(options)`
2. Run the command `npm run dev -- -t` and verify that the printed object matches the options entered.
<img width="1115" alt="image" src="https://user-images.githubusercontent.com/37782734/123729661-57b87380-d863-11eb-9923-99fb9eaddfb6.png">


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

-

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [ ] I have updated the version number in `package.json` according to Semantic Versioning specs ([semver](https://semver.org)) if I will be publishing these changes to the npm registry
