### PR TITLE
Remove csv export option from CLI

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -13,7 +13,6 @@ import {
   DatabaseType,
   AuthType,
   FileStorageType,
-  CSVExportType,
 } from "./optionTypes";
 
 type CommandLineArgs = Array<string>;
@@ -36,7 +35,6 @@ type OptionConfigs = {
   database: OptionConfig<DatabaseType>;
   auth: OptionConfig<void>;
   fileStorage: OptionConfig<void>;
-  csvExport: OptionConfig<void>;
   outputDir: OptionConfig<void>;
   testing: OptionConfig<void>;
 };
@@ -79,12 +77,6 @@ const OPTIONS: OptionConfigs = {
     id: "f",
     description: "Include built-in file storage features",
     message: "Would you like built-in file storage features?",
-    choices: [],
-  },
-  csvExport: {
-    id: "c",
-    description: "Include built-in csv export features",
-    message: "Would you like built-in csv export features?",
     choices: [],
   },
   outputDir: {
@@ -158,11 +150,6 @@ const parseArguments = (args: CommandLineArgs): CommandLineOptions => {
       type: "boolean",
       description: OPTIONS.fileStorage.description,
     },
-    csvExport: {
-      alias: OPTIONS.csvExport.id,
-      type: "boolean",
-      description: OPTIONS.csvExport.description,
-    },
     outputDir: {
       alias: OPTIONS.outputDir.id,
       type: "string",
@@ -181,7 +168,6 @@ const parseArguments = (args: CommandLineArgs): CommandLineOptions => {
     database: argv.database as DatabaseType,
     auth: argv.auth,
     fileStorage: argv.fileStorage,
-    csvExport: argv.csvExport,
     outputDir: argv.outputDir,
     testing: argv.testing,
   };
@@ -248,15 +234,6 @@ const promptOptions = async (
     });
   }
 
-  if (!options.csvExport) {
-    prompts.push({
-      type: "confirm",
-      name: "csvExport",
-      message: OPTIONS.csvExport.message,
-      default: false,
-    });
-  }
-
   if (!options.outputDir) {
     prompts.push({
       type: "output",
@@ -277,9 +254,6 @@ const promptOptions = async (
       fileStorage: (options.fileStorage || answers.fileStorage
         ? "file-storage"
         : "no-file-storage") as FileStorageType,
-      csvExport: (options.csvExport || answers.csvExport
-        ? "csv-export"
-        : "no-csv-export") as CSVExportType,
     },
     outputDir: options.outputDir || answers.outputDir,
   };
@@ -302,11 +276,9 @@ const confirmPrompt = async (options: Options) => {
     `You have chosen to create a ${backendName} app with a ` +
     `${apiName} API, ${databaseName} database, ${
       options.auth === "auth" ? "" : "no "
-    }built-in auth, ${
+    }built-in auth, and ${
       options.fileStorage === "file-storage" ? "" : "no "
-    }built-in file storage, and ${
-      options.csvExport === "csv-export" ? "" : "no "
-    }built-in csv export. Please confirm:`;
+    }built-in file storage. Please confirm:`;
 
   const prompt = {
     type: "confirm",

--- a/cli/optionTypes.ts
+++ b/cli/optionTypes.ts
@@ -8,15 +8,12 @@ export type AuthType = "auth" | "no-auth";
 
 export type FileStorageType = "file-storage" | "no-file-storage";
 
-export type CSVExportType = "csv-export" | "no-csv-export";
-
 export type Options = {
   backend: BackendType;
   api: APIType;
   database: DatabaseType;
   auth: AuthType;
   fileStorage: FileStorageType;
-  csvExport: CSVExportType;
 };
 
 export type CommandLineOptions = {
@@ -25,7 +22,6 @@ export type CommandLineOptions = {
   database?: DatabaseType;
   auth?: boolean;
   fileStorage?: boolean;
-  csvExport?: boolean;
   outputDir?: string;
   testing?: boolean;
 };

--- a/scrubber/scrubberConfig.json
+++ b/scrubber/scrubberConfig.json
@@ -78,13 +78,7 @@
     },
     "no-file-storage": {
       "tagsToKeep": ["no-file-storage"]
-    },
-    "csv-export": {
-      "tagsToKeep": ["csv-export"]
-    },
-    "no-csv-export": {
-      "tagsToKeep": ["no-csv-export"]
-    },
+    }
   },
   "dir": "starter-code-v2",
   "ignore": ["node_modules", ".git", "yarn.lock", "public"]

--- a/scrubber/scrubberTypes.ts
+++ b/scrubber/scrubberTypes.ts
@@ -8,7 +8,6 @@ import {
   DatabaseType,
   AuthType,
   FileStorageType,
-  CSVExportType,
 } from "../cli/optionTypes";
 
 export type ScrubberActionType = "remove" | "keep";
@@ -23,8 +22,7 @@ export type CLIOption =
   | APIType
   | DatabaseType
   | AuthType
-  | FileStorageType
-  | CSVExportType;
+  | FileStorageType;
 
 export type CLIOptionActions = {
   [key in CLIOption]: {


### PR DESCRIPTION
## Notion ticket link


<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Remove CSV export option as discussed, it will be kept in as a default feature
- This is because it's just a separate utility that is not integrated with the rest of the code, easy to remove if unneeded
- Reduces the number of combinations for testing
- Reference #22 for when the option was added

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Comment out await scrub(rootDir, options); in root index.ts and add console.log(options)
2. Run the command npm run dev -- -t and verify that the printed object matches the options entered.
<img width="1099" alt="image" src="https://user-images.githubusercontent.com/37782734/129487472-92241e48-704a-4d33-b5dc-45cf4aaf31c0.png">


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

-

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [ ] I have updated the version number in `package.json` according to Semantic Versioning specs ([semver](https://semver.org)) if I will be publishing these changes to the npm registry
