### PR TITLE
Switch fs.rmdir to fs.rm for Node.js v16 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uwblueprint/create-bp-app",
-  "version": "1.0.14",
+  "version": "1.0.15",
   "description": "Starter code generation CLI tool.",
   "main": "index.js",
   "bin": "bin/index.js",

--- a/scrubber/scrubUtils.ts
+++ b/scrubber/scrubUtils.ts
@@ -179,7 +179,7 @@ export function removeFileOrDir(filePath: string): Promise<void> {
   const stat = fs.statSync(filePath);
   if (stat.isDirectory()) {
     return new Promise((resolve, reject) =>
-      fs.rmdir(filePath, { recursive: true }, (err) => {
+      fs.rm(filePath, { recursive: true }, (err) => {
         if (err) {
           reject(err);
         }


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->
Our goal is to be always compatible with the Node LTS version, which is currently v16.13.1. Although not a breaking change, there is a deprecation warning on `fs.rmdir` when testing on this version.
```
[DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
(Use `node --trace-deprecation ...` to show where the warning was created)
```

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

Changed use of `fs.rmdir` to `fs.rm` when deleting directories

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Upgrade to Node LTS version, you can use [Volta](https://volta.sh/) to easily manage local Node versions
```bash
# if using Volta:
volta install node

# verify new Node version
node -v

# use Volta to revert to previous version (optional)
volta install node@14.15.5
```
2. Run the CLI and verify that directory deletion works as expected (at the very least, we always delete one of the `backend/typescript` or `backend/python` directories)
3. To verify that the rest of the code is compatible with Node.js v16, ensure that the CLI and scrubber succeed without errors
4. Add required .env and config files and check that the generated starter-code is runnable (`docker-compose up --build`), can optionally use E2E test scripts to verify correctness

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Does anything else break on Node v16?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [x] I have updated the version number in `package.json` according to Semantic Versioning specs ([semver](https://semver.org)) if I will be publishing these changes to the npm registry
