### PR TITLE
Add argument for using deprecated starter code

### DIFF
--- a/cli/optionTypes.ts
+++ b/cli/optionTypes.ts
@@ -24,6 +24,7 @@ export type CommandLineOptions = {
   fileStorage?: boolean;
   outputDir?: string;
   testing?: boolean;
+  deprecated?: boolean;
 };
 
 export type UserResponse = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uwblueprint/create-bp-app",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Starter code generation CLI tool.",
   "main": "index.js",
   "bin": "bin/index.js",


### PR DESCRIPTION
## Notion ticket link

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- If deprecated flag is supplied, warn the user, prompt for auth and file storage options and clone from release branch
- If deprecated flag is not supplied, do not prompt for auth and file storage options and clone from release-v2 branch
- Since --auth and --fs flags are ways to opt-in (ie. in deprecated version, leaving them out means we prompt for it as opposed to opt-out), these flags are still accepted when deprecated is false, it will just not do anything since they are automatically opt-in anyways
- Confirmation message still tells the user that they are using built-in auth and built-in file storage
- Testing flag still works for local version of starter code - the deprecated flag does affect which prompts are shown though

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

<img width="832" alt="image" src="https://user-images.githubusercontent.com/37782734/156899030-1bef96f8-cd81-465c-b3da-63741c2b7118.png">


1. Run `yarn dev --de` and verify that you get a warning and prompt for auth/file storage.

<img width="1056" alt="image" src="https://user-images.githubusercontent.com/37782734/156898753-69c0d61e-37f8-4530-8b95-1538e104bf6a.png">

2. Run `yarn dev` and verify that you do not get prompts for auth/file storage.
<img width="1065" alt="image" src="https://user-images.githubusercontent.com/37782734/156898760-e4f15545-c7ae-4df4-9be6-dca2f277d55a.png">


<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Any wording changes?

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [x] I have updated the version number in `package.json` according to Semantic Versioning specs ([semver](https://semver.org)) if I will be publishing these changes to the npm registry
