### PR TITLE
Remove trailing slash for typescript and python scrubbing directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ dist
 
 # Compiled TS
 bin/
+
+# vscode settings
+.vscode

--- a/index.ts
+++ b/index.ts
@@ -22,7 +22,7 @@ async function run() {
     const options = await cli(process.argv);
     await scrub(rootDir, options);
   } catch (err) {
-    console.log(chalk.red.bold(err.message));
+    console.log(chalk.red.bold((err as Error).message));
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uwblueprint/create-bp-app",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Starter code generation CLI tool.",
   "main": "index.js",
   "bin": "bin/index.js",

--- a/scrubber/scrubberConfig.json
+++ b/scrubber/scrubberConfig.json
@@ -3,14 +3,14 @@
     "typescript": {
       "tagsToKeep": ["typescript"],
       "filesToDelete": [
-        "backend/python/",
+        "backend/python",
         ".github/workflows/heroku-deploy-dev-py.yml"
       ]
     },
     "python": {
       "tagsToKeep": ["python"],
       "filesToDelete": [
-        "backend/typescript/",
+        "backend/typescript",
         ".github/workflows/heroku-deploy-dev-ts.yml"
       ]
     },


### PR DESCRIPTION
## Notion ticket link

<!-- Please replace with your ticket's URL -->

No ticket. Was originally part of fixing the RM bug, but that was moved to backlog.

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Removed a trailing slash for the scrubbing of typescript and python directories

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Run CLI until reaching the RM bug --> should be no double slash

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

-

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [x] I have updated the version number in `package.json` according to Semantic Versioning specs ([semver](https://semver.org)) if I will be publishing these changes to the npm registry
