### PR TITLE
Add support for scrubbing multi-line comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uwblueprint/create-bp-app",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "Starter code generation CLI tool.",
   "main": "index.js",
   "bin": "bin/index.js",

--- a/scrubber/scrubUtils.ts
+++ b/scrubber/scrubUtils.ts
@@ -6,15 +6,15 @@ import { TagNameToAction, CLIOptionActions } from "./scrubberTypes";
 const TAG_START_CHAR = "{";
 const TAG_END_CHAR = "}";
 
-const FILE_TYPE_COMMENT: { [key: string]: string } = {
-  js: "//",
-  json: "//",
-  ts: "//",
-  py: "#",
-  pyc: "#",
-  tsx: "//",
-  jsx: "//",
-  yml: "#",
+const FILE_TYPE_COMMENT: { [key: string]: string[] } = {
+  js: ["//", "/*"],
+  json: ["//"],
+  ts: ["//", "/*"],
+  py: ["#", '"""'],
+  pyc: ["#", '"""'],
+  tsx: ["//", "/*"],
+  jsx: ["//", "/*"],
+  yml: ["#"],
 };
 
 export function getAllTagsAndSetToRemove(
@@ -41,7 +41,7 @@ export function scrubFile(
       }
 
       const ext = filePath.split(".").pop();
-      const commentType = ext && FILE_TYPE_COMMENT[ext];
+      const commentTypes = ext && FILE_TYPE_COMMENT[ext];
       const scrubbedLines: string[] = [];
       let skip = false;
       let currentTag = "";
@@ -60,8 +60,8 @@ export function scrubFile(
         // Split on whitespace
         const tokens = line.trim().split(/[ ]+/);
 
-        if (commentType) {
-          if (tokens[0] !== commentType) {
+        if (commentTypes) {
+          if (!commentTypes.includes(tokens[0])) {
             tryProcessTag = false;
           }
           tokens.shift();


### PR DESCRIPTION
## Notion ticket link

N/A

<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Scrub multiple types of tags for TypeScript (/*) and Python (""")

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Add multiline comment tags to files in starter-code-v2.

TypeScript: 
```
/* auth {
// } auth */
```

Python:
```
""" auth {
# } auth """
```

2. Run the scrubber such that the option in the multiline comment is chosen.

3. Verify that the file is scrubbed properly.


## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [x] I have updated the version number in `package.json` according to Semantic Versioning specs ([semver](https://semver.org)) if I will be publishing these changes to the npm registry
