### PR TITLE
Ensured that directories are scrubbed only after files are removed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uwblueprint/create-bp-app",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "Starter code generation CLI tool.",
   "main": "index.js",
   "bin": "bin/index.js",

--- a/scrubber/scrubber.ts
+++ b/scrubber/scrubber.ts
@@ -70,16 +70,9 @@ class Scrubber {
       filesToDelete,
     ).map((filePath: string) => removeFileOrDir(filePath));
 
-    const scrubDirPromise = scrubDir(
-      this.config.dir,
-      ignoreFiles,
-      tags,
-      isDryRun,
-    );
-
     // Remove files first, then scrub.
     return Promise.all(removeFilePromises)
-      .then(() => scrubDirPromise)
+      .then(() => scrubDir(this.config!.dir, ignoreFiles, tags, isDryRun))
       .catch((err) => Promise.reject(err));
   }
 }


### PR DESCRIPTION
Thanks @helioshe4 for working on this!

## Notion ticket link

[[Bug] Unable to create a typescript backend project due to ENOTEMPTY error](https://www.notion.so/uwblueprintexecs/Bug-Unable-to-create-a-typescript-backend-project-due-to-ENOTEMPTY-error-5a8790e67d504d8fb4d6430c28121cb8?pvs=4)

## Background
- removeFilePromises runs almost simultaneously as scrubDirPromise
- race condition occurs, where removeFileOrDir and scrubDir run asynchronously, so scrubDir tries to run on files/directories that have been removed, leading to the ENOENT/ENOTEMPTY errors.

## Implementation description
- Ensure that scrubDir only runs after removeFilePromises resolves 

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Generate all variations of a TS backend (Postgres, GraphQL, REST, etc)

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

-

## Checklist

- [x] My PR name is descriptive and in imperative tense
- [x] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [x] I have run the appropriate linter(s)
- [x] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [x] I have updated the version number in `package.json` according to Semantic Versioning specs ([semver](https://semver.org)) if I will be publishing these changes to the npm registry
