### PR TITLE
Add branch selection to the testing mode 

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -37,7 +37,6 @@ type OptionConfigs = {
   fileStorage: OptionConfig<void>;
   outputDir: OptionConfig<void>;
   testing: OptionConfig<void>;
-  deprecated: OptionConfig<void>;
 };
 
 const OPTIONS: OptionConfigs = {
@@ -71,14 +70,14 @@ const OPTIONS: OptionConfigs = {
   auth: {
     id: "au",
     description:
-      "Include built-in auth features (deprecated option, always true in newest starter code)",
+      "Include built-in auth features",
     message: "Would you like built-in auth features?",
     choices: [],
   },
   fileStorage: {
     id: "f",
     description:
-      "Include built-in file storage features (deprecated option, always true in newest starter code)",
+      "Include built-in file storage features",
     message: "Would you like built-in file storage features?",
     choices: [],
   },
@@ -92,12 +91,6 @@ const OPTIONS: OptionConfigs = {
   testing: {
     id: "t",
     description: "Test locally without cloning repo",
-    choices: [],
-  },
-  deprecated: {
-    id: "de",
-    description:
-      "Use deprecated starter code (with options to opt-out of auth and file storage)",
     choices: [],
   },
 };
@@ -169,11 +162,6 @@ const parseArguments = (args: CommandLineArgs): CommandLineOptions => {
       type: "boolean",
       description: OPTIONS.testing.description,
     },
-    deprecated: {
-      alias: OPTIONS.deprecated.id,
-      type: "boolean",
-      description: OPTIONS.deprecated.description,
-    },
   });
 
   return {
@@ -184,7 +172,6 @@ const parseArguments = (args: CommandLineArgs): CommandLineOptions => {
     fileStorage: argv.fileStorage,
     outputDir: argv.outputDir,
     testing: argv.testing,
-    deprecated: argv.deprecated,
   };
 };
 
@@ -231,7 +218,7 @@ const promptOptions = async (
     });
   }
 
-  if (!options.auth && options.deprecated) {
+  if (!options.auth) {
     prompts.push({
       type: "confirm",
       name: "auth",
@@ -240,7 +227,7 @@ const promptOptions = async (
     });
   }
 
-  if (!options.fileStorage && options.deprecated) {
+  if (!options.fileStorage) {
     prompts.push({
       type: "confirm",
       name: "fileStorage",
@@ -260,12 +247,10 @@ const promptOptions = async (
 
   answers = await inquirer.prompt(prompts);
 
-  const authOption = (!options.deprecated || options.auth || answers.auth
+  const authOption = (options.auth || answers.auth
     ? "auth"
     : "no-auth") as AuthType;
-  const fileStorageOption = (!options.deprecated ||
-  options.fileStorage ||
-  answers.fileStorage
+  const fileStorageOption = (options.fileStorage || answers.fileStorage
     ? "file-storage"
     : "no-file-storage") as FileStorageType;
 
@@ -331,14 +316,6 @@ async function cli(args: CommandLineArgs): Promise<Options> {
 
   validateCommandLineOptions(commandLineOptions);
 
-  if (commandLineOptions.deprecated) {
-    console.warn(
-      chalk.yellowBright.bold(
-        "You have chosen to use a deprecated version of starter code that is no longer maintained.",
-      ),
-    );
-  }
-
   const { appOptions, outputDir } = await promptOptions(commandLineOptions);
 
   const confirm = await confirmPrompt(appOptions);
@@ -359,7 +336,7 @@ async function cli(args: CommandLineArgs): Promise<Options> {
   }
 
   if (!commandLineOptions.testing) {
-    const branch = commandLineOptions.deprecated ? "release" : "release-v2";
+    const branch = "release-v2";
 
     const clone = shell.exec(
       `git clone --single-branch --branch ${branch} https://github.com/uwblueprint/starter-code-v2.git`,

--- a/cli/optionTypes.ts
+++ b/cli/optionTypes.ts
@@ -24,7 +24,6 @@ export type CommandLineOptions = {
   fileStorage?: boolean;
   outputDir?: string;
   testing?: boolean;
-  deprecated?: boolean;
 };
 
 export type UserResponse = {

--- a/cli/optionTypes.ts
+++ b/cli/optionTypes.ts
@@ -24,9 +24,11 @@ export type CommandLineOptions = {
   fileStorage?: boolean;
   outputDir?: string;
   testing?: boolean;
+  branch?: string;
 };
 
 export type UserResponse = {
   appOptions: Options;
   outputDir: string;
+  branch: string;
 };


### PR DESCRIPTION
<!-- Give a quick summary of the implementation details, provide design justifications if necessary -->

## Implementation description

- Removed old deprecated branch options
- Added a new prompt for testing mode only 
- Sets the branch to be cloned based on user response

<!-- What should the reviewer do to verify your changes? Describe expected results and include screenshots when appropriate -->

## Steps to test

1. Run the CLI in normal mode `npm run dev` and confirm it is cloning the main branch
2. Run the CLI in testing mode `npm run dev -- --testing` 
a. Confirm that the main branch is cloned if the user hits enter without typing anything
b. Confirm that the correct branch is cloned if the user inputs a specific branch

<!-- Draw attention to the substantial parts of your PR or anything you'd like a second opinion on -->

## What should reviewers focus on?

- Is there any error checking that should be added?
- Should the branch prompt be accessible always or only in testing mode?

## Screenshots 
<img width="1141" alt="image" src="https://github.com/uwblueprint/starter-code-cli/assets/43042601/12278b6e-eeca-40f5-8485-1b0390347117">


## Checklist

- [ ] My PR name is descriptive and in imperative tense
- [ ] My commit messages are descriptive and in imperative tense. My commits are atomic and trivial commits are squashed or fixup'd into non-trivial commits
- [ ] I have run the appropriate linter(s)
- [ ] I have requested a review from the PL, as well as other devs who have background knowledge on this PR or who will be building on top of this PR
- [ ] I have updated the version number in `package.json` according to Semantic Versioning specs ([semver](https://semver.org)) if I will be publishing these changes to the npm registry
